### PR TITLE
Validate string arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ evaluateParam = function (param, esniffRes) {
 			return validStringLiteral(stripComments(str).trim());
 		} catch (e) {
 			throw customError('Wrong i18n invocation, expected string param, got: '
-				+ str + ', esniff result: ' + JSON.stringify(esniffRes));
+				+ str + ', esniff result: ' + JSON.stringify(esniffRes),
+				'I18N_WRONG_INVOCATION', { esniffResult: esniffRes });
 		}
 	}).join('+');
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var validValue         = require('es5-ext/object/valid-value')
   , esniffFun_         = esniffFun('_')
   , esniffResolveArgs  = require('esniff/resolve-arguments')
   , stripComments      = require('esniff/strip-comments')
+  , resolveConcat      = require('esniff/resolve-concat')
+  , validStringLiteral = require('esniff/valid-string-literal')
   , customError        = require('es5-ext/error/custom')
   , getESniffFun
   , evaluateParam
@@ -16,14 +18,18 @@ getESniffFun = memoize(function (prefix) {
 	return esniffFun(prefix + ".bind", { asProperty: true });
 });
 
-evaluateParam = function (param) {
-	param = stripComments(param).trim();
-	try {
-		param = new Function("'use strict'; return " + param)();
-	} catch (e) {
-		param = "";
-		console.error(e);
-	}
+evaluateParam = function (param, esniffRes) {
+	param = resolveConcat(param).map(function (str) {
+		try {
+			return validStringLiteral(stripComments(str).trim());
+		} catch (e) {
+			throw customError('Wrong i18n invocation, expected string param, got: '
+				+ str + ', esniff result: ' + JSON.stringify(esniffRes));
+		}
+	}).join('+');
+
+	param = new Function("'use strict'; return " + param)();
+
 	return param.trim();
 };
 
@@ -39,9 +45,9 @@ extractArguments = function (esniffResult) {
 
 resolveMessage = function (esniffResult) {
 	var args = extractArguments(esniffResult);
-	args[0] = evaluateParam(args[0]);
+	args[0] = evaluateParam(args[0], esniffResult);
 	if (args.length > 2) { //plural
-		args[1] = evaluateParam(args[1]);
+		args[1] = evaluateParam(args[1], esniffResult);
 		return 'n\0' + args[0] + '\0' + args[1];
 	}
 	return args[0];
@@ -56,7 +62,7 @@ module.exports = function (source/*, options*/) {
 	context = getESniffFun(i18Prefix)(source);
 	if (context[0] && context[0].raw) {
 		args = extractArguments(context[0]);
-		result.context = evaluateParam(args[0]);
+		result.context = evaluateParam(args[0], context[0]);
 	} else {
 		result.context = 'default';
 	}


### PR DESCRIPTION
From now on, esniff provides [resolve-concat](https://github.com/medikoo/esniff/blob/master/resolve-concat.js) utility, and with that we may resolve properly string concats and be sure we do not pass unverified code through eval.

So now you can validate possible string argument as `resolveConcat(string).forEach(validStringLiteral)`, and if it passes then blindly pass it through eval
